### PR TITLE
recovery: Add new rule for sys.usb.ffs.ready

### DIFF
--- a/sepolicy/recovery.te
+++ b/sepolicy/recovery.te
@@ -29,6 +29,9 @@ allow recovery sdcard_posix:file r_file_perms;
 # Control properties
 allow recovery recovery_prop:property_service set;
 
+# Set property sys.usb.ffs.ready
+allow recovery ffs_prop:property_service set;
+
 # recursive rm for wipes... :(
 allow app_data_file self:filesystem associate;
 allow recovery app_data_file:file { read open create write };


### PR DESCRIPTION
  init: avc:  denied  { set } for property=sys.usb.ffs.ready
    scontext=u:r:recovery:s0 tcontext=u:object_r:ffs_prop:s0
    tclass=property_service

Change-Id: Id3441ccc3c6a8915a5fdf50efd8c617d1242868a
