### PR TITLE
cm: sepolicy: allow platform apps to execute render scripts

### DIFF
--- a/sepolicy/platform_app.te
+++ b/sepolicy/platform_app.te
@@ -5,3 +5,6 @@ allow platform_app sdcard_posix:file create_file_perms;
 
 # Allow Gallery3D to crop user images
 allow platform_app system_app_data_file:file rw_file_perms;
+
+# Allow Gallery3D to execute render scripts
+allow platform_app app_data_file:file execute;


### PR DESCRIPTION
- Needed by Gallery3D Photo Editor to apply effects like:
  Vignette and Graduated.

Change-Id: I7b07a974fbdb77abbaba1c15a21e918406d2175b
