### PR TITLE
sepolicy: put bash in shell context

### DIFF
--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -52,3 +52,6 @@
 # fsck
 /system/bin/fsck\.ntfs                          u:object_r:fsck_exec:s0
 /system/bin/fsck\.exfat                         u:object_r:fsck_exec:s0
+
+# bash
+/system/xbin/bash                               u:object_r:shell_exec:s0


### PR DESCRIPTION
- Necessary for being able to execute commands such as 'su'
  from a non-root shell

Change-Id: Icbaaa6ff7447add65441011944bdc5d13b788c86
